### PR TITLE
깃허브 페이지 자동 배포 설정

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,5 @@
+- name: Deploy
+  uses: peaceiris/actions-gh-pages@v4
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    publish_dir: ./public

--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,5 +1,0 @@
-- name: Deploy
-  uses: peaceiris/actions-gh-pages@v4
-  with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
-    publish_dir: ./public

--- a/.github/gh-pages.yml
+++ b/.github/gh-pages.yml
@@ -10,7 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+
     steps:
+      - name: Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+
+      - name: Install Dependencies
+        run: npm install
       - uses: actions/checkout@v3
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/gh-pages.yml
+++ b/.github/gh-pages.yml
@@ -1,0 +1,19 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/.github/gh-pages.yml
+++ b/.github/gh-pages.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install Dependencies
         run: npm install
+      - name: Build
+        run: npm run build
       - uses: actions/checkout@v3
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.1.0",
+    "gh-pages": "^6.1.1",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.36.2",
     "rollup-plugin-terser": "^7.0.2",
@@ -12,9 +13,12 @@
     "build": "rollup -c",
     "watch": "rollup -c -w",
     "dev": "npm-run-all --parallel start watch",
-    "start": "serve public"
+    "start": "serve public",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d public"
   },
   "dependencies": {
     "jquery": "^3.7.1"
-  }
+  },
+  "homepage": "https://KJG04.github.io/nbc-team5/"
 }


### PR DESCRIPTION
## 설명

- gh-pages 패키지를 추가했습니다.
    - `npm run deploy`를 실행시켜서 깃허브 페이지 배포가 가능합니다.
- 깃허브 배포 액션을 추가했습니다
    - main 브랜치가 업데이트 될때마다 깃허브 페이지가 배포되는 액션을 추가하여서 따로 배포 명령어를 실행할 필요 없이 main 브랜치에 머지되면 자동으로 배포됩니다.
    - 배포된 페이지는 https://KJG04.github.io/nbc-team5/ 여기서 확인할 수 있습니다.