### PR TITLE
github pages 페이지전환 오류 해결

### DIFF
--- a/src/jeongkiInfo.html
+++ b/src/jeongkiInfo.html
@@ -97,7 +97,7 @@
             ></a>
             <a
               class="btn btn-outline-secondary btn-social mx-1"
-              href="/index.html"
+              href="./"
               target="_blank"
               ><i class="fa fa-home"></i
             ></a>

--- a/src/sungraeInfo.html
+++ b/src/sungraeInfo.html
@@ -97,7 +97,7 @@
             ></a>
             <a
               class="btn btn-outline-secondary btn-social mx-1"
-              href="/index.html"
+              href="./"
               target="_self"
               ><i class="fa fa-home"></i
             ></a>


### PR DESCRIPTION
로컬에서는 실행흐름에 문제가 없지만, Github pages에서 개인 소개 페이지에서 Home 버튼을 눌러 index.html 페이지로
이동이 불가능한 문제가 있습니다, 이에 대해 링크를 './'로 수정하여 해결합니다.